### PR TITLE
Fix handling the Email/query response

### DIFF
--- a/source/mail/MessageList.js
+++ b/source/mail/MessageList.js
@@ -314,7 +314,7 @@ JMAP.mail.handle( MessageList, {
     // ---
 
     'Email/query': function ( args, _, reqArgs ) {
-        const query = this.get( 'store' ).getQuery( getId( args ) );
+        const query = this.get( 'store' ).getQuery( getId( reqArgs ) );
         var total, hasTotal, numIds;
         if ( query ) {
             if ( args.total === undefined ) {


### PR DESCRIPTION
The server response does not echo the `filter` and `sort` arguments back anymore, causing the query that triggered the response to be not found, because a different id is generated by `getId()`.